### PR TITLE
feat: adding withQuery into the predicate

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,7 +34,7 @@ jobs:
     - run: npm run unit-test
     - run: npm run pack
     # todo: use github packages
-    - run: npm i "file:../project/efr-os-ts-mountebank-1.5.0.tgz" --save-dev
+    - run: npm i "file:../project/efr-os-ts-mountebank-1.6.0.tgz" --save-dev
       working-directory: integration-tests
     - run: npm ci
       working-directory: integration-tests

--- a/integration-tests/package-lock.json
+++ b/integration-tests/package-lock.json
@@ -80,8 +80,8 @@
       }
     },
     "@efr-os/ts-mountebank": {
-      "version": "file:../project/efr-os-ts-mountebank-1.5.0.tgz",
-      "integrity": "sha512-LE+D5qfq5fhw4kAYlDBkGrJgE8pz06n0Ugc8qvJK3lKbXg3EsmBVpXdvXT7M6AZhqoI9Hj4dc3wum/rcXJhScQ==",
+      "version": "file:../project/efr-os-ts-mountebank-1.6.0.tgz",
+      "integrity": "sha512-6T+sS6f2zCc4nUQW0VnubAtW5E/y3xwbOLh/5Lu4phxAkAoECZK+HDXSlbMrLhIoMedwCcilLDL8cVgrcLpsdw==",
       "dev": true,
       "requires": {
         "superagent": "^6.1.0",

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -25,7 +25,7 @@
     "typescript": "^4.4.2"
   },
   "devDependencies": {
-    "@efr-os/ts-mountebank": "file:../project/efr-os-ts-mountebank-1.5.0.tgz",
+    "@efr-os/ts-mountebank": "file:../project/efr-os-ts-mountebank-1.6.0.tgz",
     "@types/chai": "^4.2.21",
     "@types/mocha": "^8.2.3",
     "@types/superagent": "^4.1.12",

--- a/integration-tests/src/imposter.test.ts
+++ b/integration-tests/src/imposter.test.ts
@@ -37,7 +37,6 @@ describe('Imposter', () => {
     const request = queriedImposter.requests[0];
     expect(request.method).to.equal('GET');
     expect(request.path).to.equal(testPath);
-    console.log(queriedImposter);
   });
 
 });

--- a/integration-tests/src/mountebank.test.ts
+++ b/integration-tests/src/mountebank.test.ts
@@ -49,7 +49,7 @@ describe('Mountebank', () => {
                 .withPredicate(
                     new EqualPredicate()
                         .withMethod(HttpMethod.GET)
-                        .withPath('/sometest')
+                        .withPath('/testpath')
                         .withQuery({ foo : 'bar' })
                 )
                 .withResponse(
@@ -60,9 +60,8 @@ describe('Mountebank', () => {
         )
 
     await mb.createImposter(imposter);
-    const res404 = await request.get(`http://localhost:${port}/sometest`)
-    const res200 = await request.get(`http://localhost:${port}/sometest?foo=bar`)
-
+    const res404 = await request.get(`http://localhost:${port}/testpath`)
+    const res200 = await request.get(`http://localhost:${port}/testpath?foo=bar`)
     expect(res404.body).to.deep.equal({})
     expect(res200.body).to.deep.equal({ foo: 'bar' })
   })

--- a/integration-tests/src/mountebank.test.ts
+++ b/integration-tests/src/mountebank.test.ts
@@ -1,12 +1,7 @@
-import { assert, expect } from 'chai';
-import request = require('superagent');
+import {assert, expect} from 'chai';
 
-import {
-  HttpMethod,
-  Imposter,
-  Mountebank,
-  DefaultStub,
-} from '@efr-os/ts-mountebank';
+import {DefaultStub, EqualPredicate, HttpMethod, Imposter, Mountebank, Stub, Response } from '@efr-os/ts-mountebank';
+import request = require('superagent');
 
 const port = 12345;
 const testPath = '/testpath';
@@ -45,6 +40,32 @@ describe('Mountebank', () => {
     const responseCode = await getImposterResponseCode();
     expect(responseCode).to.equal(222);
   });
+
+  it('can use query strings', async () =>{
+    const imposter = new Imposter()
+        .withPort(port)
+        .withStub(
+            new Stub()
+                .withPredicate(
+                    new EqualPredicate()
+                        .withMethod(HttpMethod.GET)
+                        .withPath('/sometest')
+                        .withQuery({ foo : 'bar' })
+                )
+                .withResponse(
+                    new Response()
+                        .withStatusCode(200)
+                        .withJSONBody({ foo: "bar" })
+                )
+        )
+
+    await mb.createImposter(imposter);
+    const res404 = await request.get(`http://localhost:${port}/sometest`)
+    const res200 = await request.get(`http://localhost:${port}/sometest?foo=bar`)
+
+    expect(res404.body).to.deep.equal({})
+    expect(res200.body).to.deep.equal({ foo: 'bar' })
+  })
 
   it('can query an imposter', async () => {
     // act

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "unit-test": "cd project && npm run test-ci",
     "ci-integration-tests": "cd integration-tests && npm ci && npm run build",
     "integration-test": "cd integration-tests && npm run test-ci",
+    "build-and-run-integration": "npm run pack && npm run ci-integration-tests && npm run integration-test",
     "lint-test": "cd integration-tests && npm run lint",
     "release": "npm run copy-readme && cd project && npm run release",
     "copy-readme": "node ./scripts/copy-readme.js"

--- a/project/package.json
+++ b/project/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@efr-os/ts-mountebank",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Mountebank client for TS / node ",
   "scripts": {
     "release": "npm run build && npm run test && npm publish --access=public",

--- a/project/src/predicate.ts
+++ b/project/src/predicate.ts
@@ -19,6 +19,7 @@ export class FlexiPredicate implements Predicate {
   operator: Operator = Operator.equals;
   method: HttpMethod | undefined = undefined;
   path: string | undefined = undefined;
+  query: Record<string, unknown> | undefined = undefined;
   private _body?: string = undefined;
 
   headers: Map<string, string> = new Map<string, string>();
@@ -34,6 +35,10 @@ export class FlexiPredicate implements Predicate {
   }
   withPath(path: string): FlexiPredicate {
     this.path = path;
+    return this;
+  }
+  withQuery(query: Record<string, unknown>): FlexiPredicate{
+    this.query = query;
     return this;
   }
   withMethod(method: HttpMethod): FlexiPredicate {
@@ -70,6 +75,9 @@ export class FlexiPredicate implements Predicate {
     if (this.path) {
       res.path = this.path;
     }
+    if (this.query) {
+      res.query = this.query;
+    }
     if (this._body !== undefined) {
       res.body = this._body;
     }
@@ -82,6 +90,7 @@ export class FlexiPredicate implements Predicate {
 export class EqualPredicate implements Predicate {
   method: HttpMethod = HttpMethod.GET;
   path = '/';
+  query: Record<string, unknown> | undefined = undefined;
   private _body?: string = undefined;
 
   headers: Map<string, string> = new Map<string, string>();
@@ -92,6 +101,10 @@ export class EqualPredicate implements Predicate {
   }
   withPath(path: string): EqualPredicate {
     this.path = path;
+    return this;
+  }
+  withQuery(query: Record<string, unknown>): EqualPredicate {
+    this.query = query;
     return this;
   }
   withMethod(method: HttpMethod): EqualPredicate {
@@ -128,6 +141,11 @@ export class EqualPredicate implements Predicate {
     if (this.path) {
       res.path = this.path;
     }
+
+    if (this.query) {
+      res.query = JSON.stringify(this.query);
+    }
+
     if (this._body) {
       res.body = this._body;
     }


### PR DESCRIPTION
Adding in `.withQuery` support:

```javascript
new EqualPredicate()
    .withMethod(HttpMethod.GET)
    .withPath('/sometest')
    .withQuery({ foo : 'bar' })
```